### PR TITLE
Update Minecraft and Yarn mappings to version 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,3 +40,13 @@ java {
     targetCompatibility = JavaVersion.VERSION_21
     withSourcesJar()
 }
+
+def releaseJarBaseName = "NCI-v${project.mod_version}-${project.minecraft_version}"
+
+tasks.named("remapJar") {
+    archiveFileName = "${releaseJarBaseName}.jar"
+}
+
+tasks.named("remapSourcesJar") {
+    archiveFileName = "${releaseJarBaseName}-sources.jar"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 
-minecraft_version=1.21.10
-yarn_mappings=1.21.10+build.3
+minecraft_version=1.21.11
+yarn_mappings=1.21.11+build.4
 loader_version=0.18.4
-fabric_version=0.138.4+1.21.10
+fabric_version=0.141.3+1.21.11
 
 mod_version=1.0.0
 maven_group=com.nexo

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,7 +12,7 @@
   },
   "depends": {
     "fabricloader": ">=0.15.0",
-    "minecraft": "~1.21.10",
+    "minecraft": "~1.21.11",
     "fabric-api": "*"
   }
 }


### PR DESCRIPTION
Update Minecraft and Yarn mappings to version 1.21.11; adjust archive file names for remap tasks